### PR TITLE
installed dotenv and prefix the env with REACTAPP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/user-event": "^13.5.0",
         "ajv": "^8.17.1",
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "prop-types": "^15.8.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -7747,12 +7748,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -17482,6 +17486,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-scripts/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/user-event": "^13.5.0",
     "ajv": "^8.17.1",
     "axios": "^1.7.9",
+    "dotenv": "^16.4.7",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Christian Leadership Academy</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 
-export const API_BASE_URL = process.env.CLA_API_BASE_URL || 'https://cla-portal-api.onrender.com';
+// ✅ Use `process.env.REACT_APP_API_BASE_URL`
+export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
+
+console.log('🚀 API Base URL:', API_BASE_URL); // Debugging
 
 // Create axios instance with default config
 export const createAxiosInstance = () => {
@@ -11,4 +14,4 @@ export const createAxiosInstance = () => {
       'Accept': 'application/json'
     }
   });
-}; 
+};


### PR DESCRIPTION
This pull request fixes an issue where the Axios base URL was not being picked up from the .env file in a Create React App (CRA) project. The issue was due to the missing REACT_APP_ prefix, which is required for environment variables in CRA.