### PR TITLE
Improve Date Format Display in Profile Page

### DIFF
--- a/src/components/portal/intenalPages/profile/index.js
+++ b/src/components/portal/intenalPages/profile/index.js
@@ -106,7 +106,33 @@ function Profile() {
 
   const formatDate = (dateString) => {
     if (!dateString) return 'Not set';
-    return new Date(dateString).toLocaleDateString();
+    
+    const date = new Date(dateString);
+    
+    // Check if date is valid
+    if (isNaN(date)) return 'Invalid date';
+    
+    // Array of month names
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    
+    // Get day, month, and year
+    const day = date.getDate();
+    const month = months[date.getMonth()];
+    const year = date.getFullYear();
+    
+    // Function to add ordinal suffix to day (1st, 2nd, 3rd, 4th, etc.)
+    const getOrdinalSuffix = (day) => {
+      if (day > 3 && day < 21) return 'th'; // 4th through 20th
+      switch (day % 10) {
+        case 1: return 'st';
+        case 2: return 'nd';
+        case 3: return 'rd';
+        default: return 'th';
+      }
+    };
+    
+    // Format date as "4th Mar 2025"
+    return `${day}${getOrdinalSuffix(day)} ${month} ${year}`;
   };
 
   return (

--- a/src/components/portal/intenalPages/profile/index.js
+++ b/src/components/portal/intenalPages/profile/index.js
@@ -139,7 +139,7 @@ function Profile() {
         </p>
         <p className="profile-info">
           <span className="profile-label">Birthday: </span>
-          {userData.birthday ? formatDateWithOrdinal(userData.birthday) : 'Not set'}
+          {userData.birthday ? formatDateWithOrdinal(userData?.birthday) : 'Not set'}
         </p>
         <p className="profile-info">
           <span className="profile-label">Cohort: </span>

--- a/src/components/portal/intenalPages/profile/index.js
+++ b/src/components/portal/intenalPages/profile/index.js
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { ToastContainer } from 'react-toastify';
+import { formatDateWithOrdinal } from '../../../helpers/dateFormatter'; 
 
 function Profile() {
   const navigate = useNavigate();
@@ -104,37 +105,6 @@ function Profile() {
     });
   };
 
-  const formatDate = (dateString) => {
-    if (!dateString) return 'Not set';
-    
-    const date = new Date(dateString);
-    
-    // Check if date is valid
-    if (isNaN(date)) return 'Invalid date';
-    
-    // Array of month names
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    
-    // Get day, month, and year
-    const day = date.getDate();
-    const month = months[date.getMonth()];
-    const year = date.getFullYear();
-    
-    // Function to add ordinal suffix to day (1st, 2nd, 3rd, 4th, etc.)
-    const getOrdinalSuffix = (day) => {
-      if (day > 3 && day < 21) return 'th'; // 4th through 20th
-      switch (day % 10) {
-        case 1: return 'st';
-        case 2: return 'nd';
-        case 3: return 'rd';
-        default: return 'th';
-      }
-    };
-    
-    // Format date as "4th Mar 2025"
-    return `${day}${getOrdinalSuffix(day)} ${month} ${year}`;
-  };
-
   return (
     <div className="profile-container">
       <ToastContainer
@@ -169,7 +139,7 @@ function Profile() {
         </p>
         <p className="profile-info">
           <span className="profile-label">Birthday: </span>
-          {formatDate(userData.birthday)}
+          {userData.birthday ? formatDateWithOrdinal(userData.birthday) : 'Not set'}
         </p>
         <p className="profile-info">
           <span className="profile-label">Cohort: </span>


### PR DESCRIPTION

- Modified the `formatDate` function in the profile component to display dates in a more user-friendly format: "4th Mar 2025" instead of the numeric format
- Added proper ordinal suffix logic (1st, 2nd, 3rd, 4th, etc.) to format day numbers correctly
- Used abbreviated month names for cleaner display
- Implemented error handling for invalid or missing dates
- Maintained consistency with the application's UI/UX standards

#### Technical details:
- Created a helper function `getOrdinalSuffix` to determine the appropriate suffix based on the day number
- Added special handling for numbers 11-13 which are exceptions to the standard ordinal suffix pattern
- Improved error handling to gracefully manage edge cases (invalid dates, empty strings)

#### Before:
Dates were displayed in a numeric format (e.g., "4/11/2025")

#### After:
Dates now display in a more readable format with ordinal indicators (e.g., "4th Mar 2025")
